### PR TITLE
Fix: pricing 페이지 steppay 연동 & setup script에서 데모 데이터 추가

### DIFF
--- a/apps/client/app/[lng]/(dashboard)/pricing/PricingCard.tsx
+++ b/apps/client/app/[lng]/(dashboard)/pricing/PricingCard.tsx
@@ -45,7 +45,7 @@ export default async function PricingCard({
       }
     }
 
-    function demicalFormatPrice(price:number){
+    function decimalFormatPrice(price:number){
       return price.toLocaleString('en-US', {
         minimumFractionDigits: 0,
         maximumFractionDigits: 0,
@@ -61,7 +61,7 @@ export default async function PricingCard({
           </p>
         )}
         <p className="text-4xl font-medium text-foreground mb-6">
-          {getCurrency(Object.keys(currencyPrice)[0])}{demicalFormatPrice(currencyPrice[Object.keys(currencyPrice)[0]])}{' '}
+          {getCurrency(Object.keys(currencyPrice)[0])}{decimalFormatPrice(currencyPrice[Object.keys(currencyPrice)[0]])}{' '}
           <span className="text-xl font-normal text-muted-foreground">
             {t('price',{interval:recurring?.intervalCount || 1,unit:getUnit(recurring?.interval || IntervalUnit.MONTH)})}
           </span>

--- a/apps/client/app/[lng]/(dashboard)/pricing/PricingCard.tsx
+++ b/apps/client/app/[lng]/(dashboard)/pricing/PricingCard.tsx
@@ -2,34 +2,22 @@ import { Check } from 'lucide-react';
 import { SubmitButton } from './submit-button';
 import { createCheckoutAction } from '@/lib/payments/actions';
 import { useTranslation } from '@/app/i18n/useTranslation';
-import { DemoPeriodUnit, IntervalUnit } from '@/lib/payments/types/Product';
+import { DemoPeriodUnit, IntervalUnit, ProductPricedto, ProductProductDTO } from '@/lib/payments/types/Product';
 
 export default async function PricingCard({
-    name,
+    product,
     price,
-    interval,
-    features,
-    priceCode,
-    productCode,
     lng,
-    demoData,
-    unit
   }: {
-    name: string;
-    price: Record<string,number>;
-    interval: number;
-    features: string[];
-    priceCode?: string;
-    productCode?: string;
+    product: ProductProductDTO;
+    price: ProductPricedto;
     lng: string;
-    demoData: {
-      enabledDemo: boolean;
-      demoPeriod: number;
-      demoPeriodUnit: DemoPeriodUnit;
-    };
-    unit: IntervalUnit;
   }) {
     const {t} = await useTranslation(lng, 'pricing');
+    const { enabledDemo, demoPeriod, demoPeriodUnit } = product;
+    const { planName, currencyPrice, recurring, planDescription } = price;
+
+    const features = planDescription?.split('\n').map((feature) => feature.trim());
 
     function getUnit(unit: IntervalUnit | DemoPeriodUnit){
       switch(unit){
@@ -66,20 +54,20 @@ export default async function PricingCard({
     
     return (
       <div className="pt-6">
-        <h2 className="text-2xl font-medium text-foreground mb-2">{t(name)}</h2>
-        {demoData.enabledDemo && (
+        <h2 className="text-2xl font-medium text-foreground mb-2">{t(planName || '')}</h2>
+        {enabledDemo && (
           <p className="text-sm text-muted-foreground mb-4">
-            {t('trial', {trialDays: demoData.demoPeriod,unit:getUnit(demoData.demoPeriodUnit)})}
+            {t('trial', {trialDays: demoPeriod,unit:getUnit(demoPeriodUnit)})}
           </p>
         )}
         <p className="text-4xl font-medium text-foreground mb-6">
-          {getCurrency(Object.keys(price)[0])}{demicalFormatPrice(price[Object.keys(price)[0]])}{' '}
+          {getCurrency(Object.keys(currencyPrice)[0])}{demicalFormatPrice(currencyPrice[Object.keys(currencyPrice)[0]])}{' '}
           <span className="text-xl font-normal text-muted-foreground">
-            {t('price',{interval:interval,unit:getUnit(unit)})}
+            {t('price',{interval:recurring?.intervalCount || 1,unit:getUnit(recurring?.interval || IntervalUnit.MONTH)})}
           </span>
         </p>
         <ul className="space-y-4 mb-8">
-          {features.map((feature, index) => (
+          {features?.map((feature, index) => (
             <li key={index} className="flex items-start">
               <Check className="h-5 w-5 text-orange-500 mr-2 mt-0.5 flex-shrink-0" />
               <span className="text-foreground">{t(feature)}</span>
@@ -87,8 +75,8 @@ export default async function PricingCard({
           ))}
         </ul>
         <form action={createCheckoutAction}>
-          <input type="hidden" name="productCode" value={productCode} />
-          <input type="hidden" name="priceCode" value={priceCode} />
+          <input type="hidden" name="productCode" value={product.code} />
+          <input type="hidden" name="priceCode" value={price.code} />
           <SubmitButton lng={lng}/>
         </form>
       </div>

--- a/apps/client/app/[lng]/(dashboard)/pricing/page.tsx
+++ b/apps/client/app/[lng]/(dashboard)/pricing/page.tsx
@@ -11,51 +11,19 @@ export default async function PricingPage({params}: {params: Promise<{lng: strin
   const stepPayProducts = await getStepPayProducts(productCode);
   const productPrices = stepPayProducts.prices;
 
-  const basePlan = productPrices.find((product) => product.planName === 'Base');
-  const plusPlan = productPrices.find((product) => product.planName === 'Plus');
-
-  const basePrice = basePlan?.currencyPrice;
-  const plusPrice = plusPlan?.currencyPrice;
-
-  const demoData = {
-    enabledDemo: stepPayProducts.enabledDemo,
-    demoPeriod: stepPayProducts.demoPeriod,
-    demoPeriodUnit: stepPayProducts.demoPeriodUnit,
-  }
-
   return (
     <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       <div className="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
-        <PricingCard
-          demoData={demoData}
-          name={basePlan?.planName || 'Base'}
-          price={basePrice || {}}
-          unit={basePlan?.recurring?.interval || IntervalUnit.MONTH}
-          interval={basePlan?.recurring?.intervalCount || 1}
-          features={[
-            'unlimited_usage',
-            'unlimited_members',
-            'email_support',
-          ]}
-          priceCode={basePlan?.code}
-          productCode={productCode}
-          lng={lng}
-        />
-        <PricingCard
-          demoData={demoData}
-          name={plusPlan?.planName || 'Plus'}
-          price={plusPrice || {}}
-          unit={plusPlan?.recurring?.interval || IntervalUnit.MONTH}
-          interval={plusPlan?.recurring?.intervalCount || 1}
-          features={[
-            'base_plus',
-            'new_feature_plus',
-            'CS_plus',
-          ]}
-          priceCode={plusPlan?.code}
-          productCode={productCode}
-          lng={lng}
-        />
+      {
+        productPrices.map((price) => (
+          <PricingCard
+            key={price.code}
+            product={stepPayProducts}
+            price={price}
+            lng={lng}
+          />
+        ))
+      }
       </div>
     </main>
   );


### PR DESCRIPTION
### 요약
- 하드코딩 되어있던 pricing page steppay와 연동
- setup script 실행 시, 데모 데이터(상품, 플랜) steppay에 추가